### PR TITLE
Add discord URN type

### DIFF
--- a/urns/urns.go
+++ b/urns/urns.go
@@ -58,6 +58,9 @@ const (
 
 	// FacebookRefPrefix is the path prefix used for facebook referral URNs
 	FacebookRefPrefix string = "ref:"
+
+	// DiscordScheme is the scheme used for Discord identifiers (user IDs not usernames)
+	DiscordScheme string = "discord"
 )
 
 // ValidSchemes is the set of URN schemes understood by this library
@@ -77,6 +80,7 @@ var ValidSchemes = map[string]bool{
 	VKScheme:        true,
 	WhatsAppScheme:  true,
 	WeChatScheme:    true,
+	DiscordScheme:   true,
 }
 
 // IsValidScheme checks whether the provided scheme is valid
@@ -120,6 +124,11 @@ func NewFirebaseURN(identifier string) (URN, error) {
 // NewFacebookURN returns a URN for the passed in facebook identifier
 func NewFacebookURN(identifier string) (URN, error) {
 	return NewURNFromParts(FacebookScheme, identifier, "", "")
+}
+
+// NewDiscordURN returns a URN for the passed in Discord identifier
+func NewDiscordURN(identifier string) (URN, error) {
+	return NewURNFromParts(DiscordScheme, identifier, "", "")
 }
 
 // returns a new URN for the given scheme, path, query and display
@@ -273,6 +282,10 @@ func (u URN) Validate() error {
 		// validate path and query is a uuid
 		if !freshchatRegex.MatchString(path) {
 			return fmt.Errorf("invalid freshchat id: %s", path)
+		}
+	case DiscordScheme:
+		if !allDigitsRegex.MatchString(path) {
+			return fmt.Errorf("invalid discord id: %s", path)
 		}
 	}
 	return nil // anything goes for external schemes

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -23,6 +23,7 @@ func TestURNProperties(t *testing.T) {
 		{"facebook:ref:12345?foo=bar&foo=zap", "ref:12345", "", "foo=bar&foo=zap", map[string][]string{"foo": {"bar", "zap"}}},
 		{"tel:+250788383383", "0788 383 383", "", "", map[string][]string{}},
 		{"twitter:85114?foo=bar#foobar", "foobar", "foobar", "foo=bar", map[string][]string{"foo": {"bar"}}},
+		{"discord:732326982863421591", "732326982863421591", "", "", map[string][]string{}},
 	}
 	for _, tc := range testCases {
 		assert.Equal(t, string(tc.urn), tc.urn.String())
@@ -44,6 +45,7 @@ func TestIsFacebookRef(t *testing.T) {
 		{"facebook:ref:12345", true, "12345"},
 		{"facebook:12345", false, ""},
 		{"tel:25078838383", false, ""},
+		{"discord:732326982863421591", false, ""},
 	}
 	for _, tc := range testCases {
 		assert.Equal(t, tc.isFacebookRef, tc.urn.IsFacebookRef(), "is facebook ref mismatch for %s", tc.urn)
@@ -66,6 +68,7 @@ func TestFromParts(t *testing.T) {
 		{"telegram", "12345", "Jane", URN("telegram:12345#Jane"), URN("telegram:12345"), false},
 		{"whatsapp", "12345", "", URN("whatsapp:12345"), URN("whatsapp:12345"), false},
 		{"viber", "", "", NilURN, ":", true},
+		{"discord", "732326982863421591", "", URN("discord:732326982863421591"), URN("discord:732326982863421591"), false},
 	}
 
 	for _, tc := range testCases {
@@ -397,6 +400,27 @@ func TestFirebaseURNs(t *testing.T) {
 			assert.Error(t, err, "expected error for %s", tc.identifier)
 		} else {
 			assert.NoError(t, err, "unexpected error for %s", tc.identifier)
+			assert.Equal(t, tc.expected, urn, "created URN mismatch for %s", tc.identifier)
+		}
+	}
+}
+
+func TestDiscordURNs(t *testing.T) {
+	testCases := []struct {
+		identifier string
+		expected   URN
+		hasError   bool
+	}{
+		{"732326982863421591", URN("discord:732326982863421591"), false},
+		{"notadiscordID", URN("discord:notadiscordID"), true},
+		{"", NilURN, true},
+	}
+	for _, tc := range testCases {
+		urn, err := NewDiscordURN(tc.identifier)
+		if tc.hasError {
+			assert.Error(t, err, "expected error for %s", tc.identifier)
+		} else {
+			assert.NoError(t, err, "expected error for %s", tc.identifier)
 			assert.Equal(t, tc.expected, urn, "created URN mismatch for %s", tc.identifier)
 		}
 	}


### PR DESCRIPTION
We want a discord URN type so that we can address Discord users. Discord internally uses [Snowflakes](https://github.com/twitter-archive/snowflake/tree/snowflake-2010) as user IDs. It's not super easy to go from the user-readable name#discriminator format to these IDs, but it's pretty easy to go the other direction. If we are interested, it might be possible to have the proxy pass along the username and put that in the fragment so that rapidpro can use it as a display name.